### PR TITLE
renderer: Don't recenter viewport when sidebar changes sizes

### DIFF
--- a/commands.hpp
+++ b/commands.hpp
@@ -161,7 +161,7 @@ command_result twbt_cmd (color_ostream &out, std::vector <std::string> & paramet
                 r->gdispx++;
                 r->gdispy++;
 
-                r->needs_reshape = true;
+                r->needs_reshape = reshape_all;
             }
             else if (parameters[1] == "smaller")
             {
@@ -170,7 +170,7 @@ command_result twbt_cmd (color_ostream &out, std::vector <std::string> & paramet
                     r->gdispx--;
                     r->gdispy--;
 
-                    r->needs_reshape = true;
+                    r->needs_reshape = reshape_all;
                 }
             }
 
@@ -179,7 +179,7 @@ command_result twbt_cmd (color_ostream &out, std::vector <std::string> & paramet
                 r->gdispx = enabler->fullscreen ? small_map_dispx : large_map_dispx;
                 r->gdispy = enabler->fullscreen ? small_map_dispy : large_map_dispy;
 
-                r->needs_reshape = true;                    
+                r->needs_reshape = reshape_all;                    
             }
 
             else if (parameters[1][0] == '+' || parameters[1][0] == '-')
@@ -191,7 +191,7 @@ command_result twbt_cmd (color_ostream &out, std::vector <std::string> & paramet
                 r->gdispx += delta;
                 r->gdispy += delta;
 
-                r->needs_reshape = true;
+                r->needs_reshape = reshape_all;
             }
 
             else if (pcnt >= 3)
@@ -204,7 +204,7 @@ command_result twbt_cmd (color_ostream &out, std::vector <std::string> & paramet
                 {
                     r->gdispx = w;
                     r->gdispy = h;
-                    r->needs_reshape = true;
+                    r->needs_reshape = reshape_all;
                 }
                 else
                     return CR_WRONG_USAGE;   

--- a/commands.hpp
+++ b/commands.hpp
@@ -47,13 +47,16 @@ command_result multilevel_cmd (color_ostream &out, std::vector <std::string> & p
 
         else if (param0 == "fogcolor" && pcnt >= 4)
         {
-            float c[3];
+            float c[4];
             bool ok = parse_float(parameters[1], c[0]) &&
                       parse_float(parameters[2], c[1]) &&
                       parse_float(parameters[3], c[2]);
 
             if (ok)
+            {
+                c[3] = 0;
                 memcpy(fogcolor, c, sizeof(fogcolor));
+            }
             else
                 return CR_WRONG_USAGE;
         }

--- a/config.hpp
+++ b/config.hpp
@@ -577,7 +577,7 @@ static bool load_overrides()
                 int idx = tilesets.size() - 1;
                 string n = (tokens.size() == 4) ?
                     tokens[3] :
-                    static_cast<std::ostringstream*>(&(std::ostringstream() << idx))->str();
+                    int_to_string(idx);
                 tilesetnames[n] = idx;
             }
 

--- a/dwarfmode.hpp
+++ b/dwarfmode.hpp
@@ -40,7 +40,7 @@ struct dwarfmode_hook : public df::viewscreen_dwarfmodest
         if (gmenu_w != menu_w_new)
         {
             gmenu_w = menu_w_new;
-            r->needs_reshape = true;
+            r->needs_reshape = reshape_sidebar;
         }
     }
 
@@ -70,7 +70,7 @@ struct dwarfmode_hook : public df::viewscreen_dwarfmodest
         if (gmenu_w < 0)
         {
             gmenu_w = get_menu_width();
-            r->needs_reshape = true;
+            r->needs_reshape = reshape_sidebar;
         }
 
         r->reshape_zoom_swap();

--- a/renderer.hpp
+++ b/renderer.hpp
@@ -52,7 +52,7 @@ static void write_tile_vertexes(GLfloat x, GLfloat y, GLfloat *vertex, float d)
 
 renderer_cool::renderer_cool()
 {
-    dummy = 'TWBT';
+    dummy = TWBT_MAGIC_IDENT;
     gvertexes = 0, gfg = 0, gtex = 0;
     gdimx = 0, gdimy = 0, gdimxfull = 0, gdimyfull = 0;
     gdispx = 0, gdispy = 0;

--- a/renderer_twbt.h
+++ b/renderer_twbt.h
@@ -24,6 +24,13 @@ typedef _renderer_opengl renderer_opengl; // This is to make Linux happy
 
 const uint32_t TWBT_MAGIC_IDENT = 0x54574254;
 
+enum reshape_status
+{
+    reshape_none,
+    reshape_sidebar,
+    reshape_all,
+};
+
 struct renderer_cool : renderer_opengl
 {
     uint32_t dummy;
@@ -32,7 +39,7 @@ struct renderer_cool : renderer_opengl
     int gdimx, gdimy, gdimxfull, gdimyfull;
     int gdispx, gdispy;
     float goff_x, goff_y, gsize_x, gsize_y;
-    bool needs_reshape;
+    reshape_status needs_reshape;
     int needs_zoom;
     bool needs_full_update;
     unsigned char *gscreen;

--- a/renderer_twbt.h
+++ b/renderer_twbt.h
@@ -22,6 +22,8 @@ struct _renderer_opengl : public df::renderer
 };
 typedef _renderer_opengl renderer_opengl; // This is to make Linux happy
 
+const uint32_t TWBT_MAGIC_IDENT = 0x54574254;
+
 struct renderer_cool : renderer_opengl
 {
     uint32_t dummy;
@@ -66,7 +68,7 @@ struct renderer_cool : renderer_opengl
     virtual void _last_vmethod() {};
 
     bool is_twbt() {
-        return (this->dummy == 'TWBT');
+        return (this->dummy == TWBT_MAGIC_IDENT);
     };
 
     void output_string(int8_t color, int x, int y, std::string str)

--- a/twbt.cpp
+++ b/twbt.cpp
@@ -165,6 +165,13 @@ struct tile_overrides {
     bool has_material_overrides = false;
 };
 
+inline string int_to_string(const int n)
+{
+    std::ostringstream ss;
+    ss << n;
+    return ss.str();
+}
+
 static struct tile_overrides *overrides[256];
 
 long *text_texpos, *map_texpos;


### PR DESCRIPTION
When the fortress mode sidebar changes sizes, the viewport should remain
fixed at the left side. This behavior of Dwarf Fortress is expected by
various calculations that place the cursor, both in Dwarf Fortress and
in DFHack plugins.

Keep the re-centering behavior for zoom and any other changes, as it is
more friendly than zooming from the top left corner.

## How to repeat
1) Run DF without TWBT. Hit TAB until the sidebar is off. Press k. Notice that the view does not move.
2) Run DF with TWBT. Turn off sidebar, press k. Notice the view moves.
3) Notice that the cursor is off to the left of the view, not centered as it should be.
4) Notice that dfhack's `tweak stable-cursor` doesn't work when the sidebar is off.