### PR TITLE
CMakeLists.txt: Rely on dfhack/CMake/Common.cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,33 @@
+cmake_minimum_required(VERSION 3.22)
+set(CMAKE_CXX_STANDARD 11)
 PROJECT( twbt )
 
-SET( PROJECT_SRCS twbt.cpp )
-SET( TWBT_VER "5.xx" )
+SET( TWBT_VER "6.xx" )
+SET( DFVERNUM 04705 )
+SET( DFHACKVER 0.47.05-r4 )
+SET( DF /data/develop/projects/dwarf-fortress/install )
+SET( DFHACK /data/develop/projects/dwarf-fortress/dfhack )
+SET( DFHACK_BUILD ${DFHACK}/build )
+set( CMAKE_SHARED_LIBRARY_PREFIX_CXX "" )
+SET( PLUGIN_TARGET twbt.plug)
+SET( CMAKE_CXX_FLAGS "-m64 -DLINUX_BUILD -O3 -D_GLIBCXX_USE_CXX11_ABI=0 -DDFHACK_VERSION=\"${DFHACKVER}\" -DDF_${DFVERNUM} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
+#SET( CMAKE_CXX_FLAGS "-DDFHACK_VERSION=\"${DFHACKVER}\" -DDF_${DFVERNUM} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
 
-STRING( REGEX REPLACE "\\." "" DV_VS "${DF_VERSION}" )
+# source files
+SET( SRC twbt.cpp )
+SET( DEP renderer.hpp config.hpp dungeonmode.hpp dwarfmode.hpp renderer_twbt.h commands.hpp plugin.hpp tileupdate_text.hpp tileupdate_map.hpp patches.hpp zoomfix.hpp buildings.hpp items.hpp units.hpp Makefile legacy/renderer_legacy.hpp legacy/twbt_legacy.hpp)
 
-SET( CMAKE_CXX_FLAGS "-m64 -O3 -DDFHACK_VERSION=\"${DFHACK_VERSION}\" -DDF_${DV_VS} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
+# include directories
+include_directories(${DFHACK}/library/include)
+include_directories(${DFHACK}/library/proto)
+include_directories(${DFHACK}/depends/protobuf)
+include_directories(${DFHACK}/depends/lua/include)
 
-IF( APPLE )
-  IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x -Wno-multichar -framework OpenGL -undefined dynamic_lookup" )
-  ELSE()
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x -stdlib=libstdc++ -Wno-tautological-compare -framework OpenGL -mmacosx-version-min=10.6 -undefined dynamic_lookup" )
-  ENDIF()
-ELSE( APPLE )
-  SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x" )
-ENDIF( APPLE )
-
-DFHACK_PLUGIN( twbt ${PROJECT_SRCS} )
-
-# add_subdirectory( plugins ) Already included in dfhack?
+# plugin target
+add_compile_options("-fpermissive")
+#add_link_options("-L${DFHACK_BUILD}/library -ldfhack -ldfhack-version")
+link_directories("${DFHACK_BUILD}/library")
+add_library(${PLUGIN_TARGET} SHARED ${SRC} ${DEP})
+target_link_libraries(${PLUGIN_TARGET} PUBLIC dfhack dfhack-version)
+install(TARGETS ${PLUGIN_TARGET}
+        LIBRARY DESTINATION ${DF}/hack/plugins)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,26 @@
 cmake_minimum_required(VERSION 3.22)
-set(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_VERBOSE_MAKEFILE ON)
+SET(DFHACK ../dfhack)
+SET(DFHACK_BUILD ${DFHACK}/build)
+
+IF(EXISTS "${DFHACK_BUILD}/CMakeCache.txt")
+    LOAD_CACHE("${DFHACK_BUILD}" READ_WITH_PREFIX DEFAULT_ CMAKE_INSTALL_PREFIX)
+    SET(CMAKE_INSTALL_PREFIX ${DEFAULT_CMAKE_INSTALL_PREFIX})
+ENDIF()
+
+#set(CMAKE_CXX_STANDARD 11)
 PROJECT( twbt )
 
+include(${DFHACK}/CMake/Common.cmake)
+string(REPLACE "." "" DFVERNUM ${DF_VERSION})
 SET( TWBT_VER "6.xx" )
-SET( DFVERNUM 04705 )
-SET( DFHACKVER 0.47.05-r4 )
-SET( DF /data/develop/projects/dwarf-fortress/install )
-SET( DFHACK /data/develop/projects/dwarf-fortress/dfhack )
-SET( DFHACK_BUILD ${DFHACK}/build )
+#SET( DFVERNUM 04705 )
+#SET( DFHACKVER 0.47.05-r4 )
+#SET( DF /data/develop/projects/dwarf-fortress/install )
+#SET( DFHACK /data/develop/projects/dwarf-fortress/dfhack )
 set( CMAKE_SHARED_LIBRARY_PREFIX_CXX "" )
 SET( PLUGIN_TARGET twbt.plug)
-SET( CMAKE_CXX_FLAGS "-m64 -DLINUX_BUILD -O3 -D_GLIBCXX_USE_CXX11_ABI=0 -DDFHACK_VERSION=\"${DFHACKVER}\" -DDF_${DFVERNUM} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
+#SET( CMAKE_CXX_FLAGS "-m64 -DLINUX_BUILD -O3 -D_GLIBCXX_USE_CXX11_ABI=0 -DDFHACK_VERSION=\"${DFHACKVER}\" -DDF_${DFVERNUM} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
 #SET( CMAKE_CXX_FLAGS "-DDFHACK_VERSION=\"${DFHACKVER}\" -DDF_${DFVERNUM} -DTWBT_VER=\"\\\"${TWBT_VER}\\\"\"" )
 
 # source files
@@ -23,11 +33,26 @@ include_directories(${DFHACK}/library/proto)
 include_directories(${DFHACK}/depends/protobuf)
 include_directories(${DFHACK}/depends/lua/include)
 
+find_package(PNG)
+if(NOT PNG_FOUND)
+    # XXX Probably this is wrong. It appears df-twbt/libpng has precompiled
+    # libs for Windows? Probably it should be a submodule that has the
+    # actual libpng source (which builds with CMake).
+    include_directories(libpng)
+endif()
+add_definitions(${PNG_DEFINITIONS})
+#target_link_libraries(${PLUGIN_TARGET} ${PNG_LIBRARIES})
+
 # plugin target
+# This is a string, not a number!
+add_compile_definitions(TWBT_VER=\"${TWBT_VER}\")
+add_compile_definitions(DFHACK_VERSION=${DFHACK_VERSION})
+add_compile_definitions(DF_${DFVERNUM})
 add_compile_options("-fpermissive")
+add_compile_options("-Wno-error")
 #add_link_options("-L${DFHACK_BUILD}/library -ldfhack -ldfhack-version")
 link_directories("${DFHACK_BUILD}/library")
 add_library(${PLUGIN_TARGET} SHARED ${SRC} ${DEP})
 target_link_libraries(${PLUGIN_TARGET} PUBLIC dfhack dfhack-version)
 install(TARGETS ${PLUGIN_TARGET}
-        LIBRARY DESTINATION ${DF}/hack/plugins)
+    LIBRARY DESTINATION ${DFHACK_PLUGIN_DESTINATION})


### PR DESCRIPTION
This depends on https://github.com/DFHack/dfhack/pull/2091

Please see that PR for a basic rational.

This makes many major changes on top of the working CMake patch from @cppcooper:

- Use `../dfhack` as default DFHack source dir
- Remove all compiler settings, and import the DFHack rules that define them
- Same for version info
- Add find_package(PNG) (not sure I did this right at all!)
- Add -Wno-error because there are many warnings in TWBT source. Most are signed/unsigned comparisons and similar that are *probably* benign.

I am quite sure this patch is broken. I haven't gotten a Windows dev env set up to test it with, and don't have OS X. I've only tested on my SuSE Linux laptop. Further, the actual generated CMake settings used in the DFHack build are largely being ignored, and it's relying only on the *rules* that DFHack uses. Probably a mix of rules and cached results needs to be used. Here's a nice explanation of `LOAD_CACHE()`:  https://cmake.org/pipermail/cmake/2011-July/045616.html

But I think *something* like this approach should work, and is the only real way to get past the hard-coded hacks of the old Makefile approach. If we're using CMake in both projects, we really should get them talking to each other in my opinion.

To build with this, I did:

1. Clone `dfhack` and `df-twbt` repos next to each other in the same directory
2. ```sh
    cd dfhack
    rm -rf build/CMake*
    cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=/opt/dwarffortress -DCMAKE_BUILD_TYPE=RelWithDebInfo
    ninja -Cbuild install
    ```
4. ```sh
    cd ../df-twbt
    rm -rf build
    cmake -Bbuild -GNinja
    ninja -Cbuild install
   ```
