### PR TITLE
int_to_string is now part of MiscUtils

### DIFF
--- a/twbt.cpp
+++ b/twbt.cpp
@@ -165,13 +165,6 @@ struct tile_overrides {
     bool has_material_overrides = false;
 };
 
-inline string int_to_string(const int n)
-{
-    std::ostringstream ss;
-    ss << n;
-    return ss.str();
-}
-
 static struct tile_overrides *overrides[256];
 
 long *text_texpos, *map_texpos;


### PR DESCRIPTION
Refactoring within DFHack has exposed an identical copy of this function. We can remove this copy.